### PR TITLE
Use toBe to compare strings

### DIFF
--- a/generators/app/templates/src/app/components/home/home.component.spec.ts
+++ b/generators/app/templates/src/app/components/home/home.component.spec.ts
@@ -13,7 +13,7 @@ describe('Home Component : ', () => {
   );
   it('should say \'We Start Here\'',
     inject([ HomeComponent ], ( app: HomeComponent ) => {
-      expect( app.weStartHere ).toBeTruthy( 'We Start Here!' );
+      expect( app.weStartHere ).toBe( 'We Start Here!' );
     })
   );
 });


### PR DESCRIPTION
`expect( app.weStartHere ).toBeTruthy( 'FooBar' );` would be also true and I figure out this is not the expected behaviour
